### PR TITLE
Remove unused moveZDown declarations from Movement headers

### DIFF
--- a/Mining_Research/Reset/startPosition/Movement.h
+++ b/Mining_Research/Reset/startPosition/Movement.h
@@ -8,7 +8,6 @@
 
 class Movement {
     public:
-        void moveZDown(int steps);
         void moveYDown(int steps);
         void moveYUp(int steps);
         void moveXLeft(int steps);

--- a/Mining_Research/runtest/Movement.h
+++ b/Mining_Research/runtest/Movement.h
@@ -8,7 +8,6 @@
 
 class Movement {
     public:
-        void moveZDown(int steps);
         void moveYDown(int steps);
         void moveYUp(int steps);
         void moveXLeft(int steps);


### PR DESCRIPTION
## Summary
- remove the unused moveZDown declaration from the runtest Movement header
- remove the unused moveZDown declaration from the reset Movement header

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfd9f85acc832898ec58be289e9a22